### PR TITLE
Set up packaging/testing/license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+# Config file for automatic testing at travis-ci.org
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev" # 3.7 development branch
+#  - "pypy"  # PyPy not working at present on Travis
+#  - "pypy3"
+
+# commands to install dependencies
+install:
+  - "python setup.py install"
+
+# command to run tests
+script: "python -m unittest maff_test"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) Christopher Knight
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) Christopher Knight
+Copyright (c) Christopher Night
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/maff.py
+++ b/maff.py
@@ -4,6 +4,9 @@
 from __future__ import division
 import math
 
+__version__ = '0.1'
+__versioninfo__ = (0, 1)
+
 # Circle constant. Already available in 3.6+
 tau = math.tau if hasattr(math, "tau") else 2 * math.pi
 
@@ -85,7 +88,7 @@ def softapproach(x, target, dlogx, dxmax = float("inf"), dymin = 0.1):
 	if f * d > dxmax: f = dxmax / d
 	if (1 - f) * d < dymin: return target
 	return [mix(a, b, f) for a, b in zip(x, target)] if vector else mix(x, target, f)
-	
+
 
 # Polar coordinates
 def CS(theta, r = 1):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+from setuptools import setup
+
+
+setup(
+    name='maff',
+    version='0.1',
+    description='Python convenience functions that I wish were in the math module',
+    long_description=open('README.md').read(),
+    url='https://github.com/cosmologicon/maff',
+    author='Christopher Knight',
+    author_email='cosmologicon@gmail.com',
+    py_modules=['maff'],
+    test_suite="maff_test",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Topic :: Scientific/Engineering :: Mathematics",
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description='Python convenience functions that I wish were in the math module',
     long_description=open('README.md').read(),
     url='https://github.com/cosmologicon/maff',
-    author='Christopher Knight',
+    author='Christopher Night',
     author_email='cosmologicon@gmail.com',
     py_modules=['maff'],
     test_suite="maff_test",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py27,py33,py34,py35,py36
+
+[testenv]
+commands=python -V && python -m unittest maff_test


### PR DESCRIPTION
This adds various bits of configuration to allow maff to be packaged on PyPI - which I've already done to avoid name squatting: https://pypi.python.org/pypi/maff

I can add you as owner of the package if you let me know your PyPI username.

I chose a 2-clause BSD license because no license was included. I hope this is acceptable.

In terms of testing, you can now test in several ways:

* By running `python setup.py test`
* By running `tox`, this will test against all currently supported Python interpreters. You need to have them installed; if you're on Ubuntu, use the [deadsnakes PPA](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes) for this.
* There's a Travis configuration to set it up to build on [Travis](https://travis-ci.org/). Setting this up is super easy - go to https://travis-ci.org/, sign in with Github authentication, then toggle the switch for cosmologicon/maff to On. Travis will then run tests on each push and for every pull request.